### PR TITLE
fix maps.google.com 404

### DIFF
--- a/local/proxy.ini
+++ b/local/proxy.ini
@@ -74,6 +74,7 @@ https?://www\.google\.com\.hk/search\?(.+) = https://www.google.com/ncr#$1
 ; .c.youtube.com =
 ; .youtube.com = google_hk
 ; .googlevideo.com =
+maps.google.com = withgae
 
 [pac]
 enable = 1


### PR DESCRIPTION
修正404页面 https://maps.google.com/locationhistory/