### PR TITLE
Update proxy.py

### DIFF
--- a/local/proxy.py
+++ b/local/proxy.py
@@ -73,6 +73,7 @@ import ConfigParser
 import errno
 import httplib
 import io
+import locale
 import Queue
 import random
 import re
@@ -448,7 +449,7 @@ class GAEFetchPlugin(BaseFetchPlugin):
             else:
                 status = 502
                 headers = {'Content-Type': 'text/html'}
-                content = message_html('502 URLFetch failed', 'Local URLFetch %r failed' % handler.path, '<br>'.join(repr(x) for x in errors))
+                content = message_html('502 URLFetch failed', 'Local URLFetch %r failed' % handler.path, '<br>'.join(str(x).decode(locale.getpreferredencoding()) for x in errors))
             return handler.handler_plugins['mock'].handle(handler, status, headers, content)
         logging.info('%s "GAE %s %s %s" %s %s', handler.address_string(), handler.command, handler.path, handler.protocol_version, response.status, response.getheader('Content-Length', '-'))
         try:


### PR DESCRIPTION
Make the error html page show the understandable character instead of unicode.
before this patch,you may get message in error page like this:
Local URLFetch 'http://blog.denevell.org/android-viewdraghelper-example-tutorial.html' failed
error(10013, '\xd2\xd4\xd2\xbb\xd6\xd6\xb7\xc3\xce\xca\xc8\xa8\xcf\xde\xb2\xbb\xd4\xca\xd0\xed\xb5\xc4\xb7\xbd\xca\xbd\xd7\xf6\xc1\xcb\xd2\xbb\xb8\xf6\xb7\xc3\xce\xca\xcc\xd7\xbd\xd3\xd7\xd6\xb5\xc4\xb3\xa2\xca\xd4\xa1\xa3')
error(10013, '\xd2\xd4\xd2\xbb\xd6\xd6\xb7\xc3\xce\xca\xc8\xa8\xcf\xde\xb2\xbb\xd4\xca\xd0\xed\xb5\xc4\xb7\xbd\xca\xbd\xd7\xf6\xc1\xcb\xd2\xbb\xb8\xf6\xb7\xc3\xce\xca\xcc\xd7\xbd\xd3\xd7\xd6\xb5\xc4\xb3\xa2\xca\xd4\xa1\xa3') 
while after the patch,the message like this:
Local URLFetch 'http://blog.denevell.org/android-viewdraghelper-example-tutorial.html' failed
[Errno 10013] 以一种访问权限不允许的方式做了一个访问套接字的尝试。
[Errno 10013] 以一种访问权限不允许的方式做了一个访问套接字的尝试。