### PR TITLE
make goagent support new android sdk download

### DIFF
--- a/local/proxy.ini
+++ b/local/proxy.ini
@@ -31,6 +31,7 @@ google_talk = talk.google.com|talk.l.google.com|talkx.l.google.com
 
 [profile]
 dl-ssl.google.com = withgae
+dl.google.com = withgae
 play.google.com = withgae
 wenda.google.com.hk = withgae
 clients.google.com = withgae,noforcehttps


### PR DESCRIPTION
Google changed the new download repository url for android sdk.